### PR TITLE
Add: Policy to handle cross origin requests

### DIFF
--- a/asc-courses-api/src/main/java/com/asc/courses/config/WebConfig.java
+++ b/asc-courses-api/src/main/java/com/asc/courses/config/WebConfig.java
@@ -1,0 +1,19 @@
+package com.asc.courses.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        // Apply CORS settings to all endpoints
+        registry.addMapping("/**")  
+            // Allowed origin: React App
+            .allowedOrigins("http://localhost:5173")
+            // Allowed HTTP Methods
+            .allowedMethods("GET", "POST", "PUT", "DELETE");
+        }   
+}


### PR DESCRIPTION
Added global config to support cross-origin requests to all endpoints; Server will add an `Access-Control-Allow-Origin` header as part of the response.